### PR TITLE
Update plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-  id 'com.gradle.plugin-publish' version '0.9.4'
-  id 'de.lemona.gradle'          version '0.1.0'
+  id 'com.gradle.plugin-publish' version '0.9.9'
+  id 'de.lemona.gradle'          version '0.1.2'
 }
 
 apply plugin: 'java'


### PR DESCRIPTION
## Objective (Required)
Update the plugins used by this project.

The old gradle publish plugin actually has a problem where it will upload an incorrect POM to the gradle plugin repository: https://issues.gradle.org/browse/GRADLE-3359

If an incorrect POM is uploaded once, then even deleting that version using the gradle online interface won't reupload the POM meaning that the only way to upload the fixed POM is to bump the version number.

## Update Summary (Required)
- Update gradle publish plugin
- Update self