### PR TITLE
Fix jar publishing

### DIFF
--- a/src/main/groovy/de/lemona/gradle/plugins/EclipsePlugin.groovy
+++ b/src/main/groovy/de/lemona/gradle/plugins/EclipsePlugin.groovy
@@ -30,7 +30,7 @@ class EclipsePlugin implements Plugin<Project> {
       // Create a "project.properties" for eclipse
       task([group: 'IDE'], 'eclipseAndroid') {
           description 'Generate the local "project.properties" file for Android'
-      } << {
+      }.doLast {
         def prop = new Properties()
         prop.target = "${android.compileSdkVersion}".toString()
         def propFile = new File("${projectDir}/project.properties");

--- a/src/main/groovy/de/lemona/gradle/plugins/PublishPlugin.groovy
+++ b/src/main/groovy/de/lemona/gradle/plugins/PublishPlugin.groovy
@@ -126,8 +126,12 @@ class PublishPlugin implements Plugin<Project> {
 
             def _jarTaskName = 'package' + _variantName + 'Jar'
             if (tasks.findByName(_jarTaskName) == null) {
-              task([type: Jar], _jarTaskName) { }
               println 'No Jar task found, creating one: ' + _jarTaskName
+              task([type: Jar], _jarTaskName) {
+                dependsOn variant.javaCompile
+                from variant.javaCompile.destinationDir
+                exclude '**/R.class', '**/R$*.class', '**/R.html', '**/R.*.html'
+              }
             }
 
             // Prepare our publication artifact (from the AAR)


### PR DESCRIPTION
## Objective (Required)
As of Android Gradle Plugin 1.5.0, there is no longer a `packageReleaseJar` task by default. We added an empty task to avoid build errors but this means that the plugin generates an empty jar file. Fix this by generating a proper jar file.

Ref: https://stackoverflow.com/a/19967914

## Update Summary (Required)
- Add a working jar task if none exists  
- `<<` is deprecated, replace it with `doLast`