### PR TITLE
Workaround scala-library Resolution Problem

### DIFF
--- a/src/main/groovy/de/lemona/gradle/plugins/PublishPlugin.groovy
+++ b/src/main/groovy/de/lemona/gradle/plugins/PublishPlugin.groovy
@@ -41,7 +41,13 @@ class PublishPlugin implements Plugin<Project> {
               // Collect all artifacts we depend on
               Set<ResolvedArtifact> resolvedArtifacts = []
               configurations.findAll {
-                  canBeResolved(it)
+                // For Scala projects, Gradle depends on zinc which depends on an older version of the scala-library.
+                // In order to allow the use of newer versions of the scala-library, ignore the dependency from zinc.
+                if (it.name == 'zinc') {
+                  return false
+                }
+
+                canBeResolved(it)
               }.each { config ->
                 resolvedArtifacts.addAll config.resolvedConfiguration.resolvedArtifacts
               }


### PR DESCRIPTION
For Scala, Gradle creates a configuration named `zinc` which depends on the version of the zinc compiler and `scala-library` needed to compile the project. Since this is only used during compilation, ignore this task when freezing resolved versions.

This fixes a problem where we want to use a newer version of `scala-library` in a project but it gets overwritten to the version resolved by the `zinc` configuration.

See: https://discuss.gradle.org/t/default-scala-compiler-doesnt-work-in-gradle-2-12-scala-2-11/15328/5

This is probably implemented using compile-only dependencies: https://blog.gradle.org/introducing-compile-only-dependencies