### PR TITLE
Downgrade publish plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-gradle-plugin'
-    id 'com.gradle.plugin-publish' version '0.10.1'
+    id 'com.gradle.plugin-publish' version '0.9.9'
     id 'de.lemona.gradle' version '0.1.5'
 }
 


### PR DESCRIPTION
Starting with version 0.10.0, the gradle publish plugin does some magic if used with the java-gradle-plugin (https://plugins.gradle.org/plugin/com.gradle.plugin-publish/0.10.0). This seems to break uploading for us. Not sure why, but I'd rather not debug it at the moment. For now, downgrade to the previous version.