### PR TITLE
Adapt to Gradle5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 build/
 local.properties
 
-# Lemonade
+# Private
 lemonade.properties

--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
-Lemonade Lab Gradle Plugins
+LEOMO Gradle Plugins
 ===========================
 
 This project contains a set of [Gradle](http://gradle.org/) plugins to
 customize the standard build conventions to the ones used at
-[Lemonade Lab](http://lemona.de/)
+[LEOMO, Inc.](http://leomo.io/)
 
 * [Main Plugin](#main-plugin)
 * [Android Plugin](#android-plugin)
 * [Publishing Plugin](#publishing-plugin)
 * [S3 Repository Plugin](#s3-repository-plugin)
-
 
 Supported Version
 -----------------
@@ -66,10 +65,11 @@ This plugin will:
    > be left untouched.</small>
 3. Initialize the project's `version` filed following Lemonade's
    [versioning convertions](#versioning)
-4. Set up three repositories for dependency resolution:
+4. Set up repositories for dependency resolution:
    * Lemonade's OSS repository on [Bintray](https://bintray.com/lemonade/maven).
    * Bintray's [JCenter](https://bintray.com/lemonade/maven) repository.
    * The [Maven Central](http://search.maven.org/) repository.
+   * [Google's Maven](https://maven.google.com/) repository.
 5. Set up the rest of our plugins:
    * Add the [Android Plugin](#android-plugin) if either the
      `com.android.application` or `com.android.library` plugins were specified
@@ -152,13 +152,11 @@ repository under `${buildDir}/maven`.
 For Java artifacts the main java component, sources and javadoc jars will
 be published.
 
-For Android _libraries_ the the jar, aar, sources and javadoc jars will be
-published under the `${buildDir}/maven/${variant.name}` directory.
+For Android _libraries_ the aar file will be published.
 
-By default the `release` variant will be published, to publish a _different_
-build variant specify its name in the `publishVariant` project property or
-`PUBLISH_VARIANT` environment variable.
+For Android _app_ an zip file which contains the apk file and the obfuscation mapping file.
 
+The `release` variant will be published.
 
 S3 Repository Plugin
 --------------------

--- a/build.gradle
+++ b/build.gradle
@@ -24,12 +24,12 @@ gradle.taskGraph.whenReady { taskGraph ->
 pluginBundle {
     website = 'https://www.leomo.io/'
     vcsUrl = 'https://github.com/LemonadeLabInc/gradle-snippets'
-    description = 'Lemonade Android and Java conventions plugin'
-    tags = ['lemonade']
+    description = 'LEOMO Android and Java conventions plugin'
+    tags = ['leomo']
     plugins {
         gradle {
             id = 'de.lemona.gradle'
-            displayName = 'Lemonade Gradle plugin'
+            displayName = 'LEOMO Gradle plugin'
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group   = de.lemona
-version = 0.2
+version = 0.3

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/src/main/groovy/de/lemona/gradle/plugins/GradlePlugin.groovy
+++ b/src/main/groovy/de/lemona/gradle/plugins/GradlePlugin.groovy
@@ -21,6 +21,7 @@ class GradlePlugin implements Plugin<Project> {
 
             // Trigger actions on our plugins
             plugins.withId('java') { project.apply plugin: 'de.lemona.gradle.java' }
+            plugins.withId('java-library') { project.apply plugin: 'de.lemona.gradle.java' }
             plugins.withId('maven-publish') { project.apply plugin: 'de.lemona.gradle.publish' }
 
             plugins.withId('com.android.application') {

--- a/src/main/groovy/de/lemona/gradle/plugins/PublishPlugin.groovy
+++ b/src/main/groovy/de/lemona/gradle/plugins/PublishPlugin.groovy
@@ -104,10 +104,4 @@ class PublishPlugin implements Plugin<Project> {
             }
         }
     }
-
-    def canBeResolved(configuration) {
-        // isCanBeResolved() was introduced with Gradle 3.3 so check for its existence first
-        configuration.metaClass.respondsTo(configuration, "isCanBeResolved") ?
-                configuration.isCanBeResolved() : true
-    }
 }

--- a/src/main/groovy/de/lemona/gradle/plugins/PublishPlugin.groovy
+++ b/src/main/groovy/de/lemona/gradle/plugins/PublishPlugin.groovy
@@ -61,72 +61,19 @@ class PublishPlugin implements Plugin<Project> {
                 /* ================================================================== */
 
                 plugins.withId('com.android.library') {
+                    afterEvaluate {
+                        publishing {
+                            publications {
+                                def _group = group
+                                def _name = name
+                                def _version = version
+                                release(MavenPublication) {
+                                    from components.release
 
-                    // By default we publish the "release" variant
-                    def _variant = Utilities.resolveValue(project, 'publishVariant', 'PUBLISH_VARIANT', 'release')
-                    def _variantName = _variant.capitalize()
-
-                    // Process all the library variants
-                    android.libraryVariants.all { variant ->
-                        if (variant.name != _variant) {
-                            logger.info('Skipping publishing of "{}" variant', variant.name)
-                            return;
-                        }
-
-                        // Sources JAR for publishing
-                        def _publishSourcesJar = task([type: Jar], 'publish' + _variantName + 'SourcesJar') {
-                            classifier = 'sources'
-                            from android.sourceSets.main.javaDirectories
-                            from android.sourceSets.main.resourcesDirectories
-                        }
-
-                        def _jarTaskName = 'package' + _variantName + 'Jar'
-                        if (tasks.findByName(_jarTaskName) == null) {
-                            println 'No Jar task found, creating one: ' + _jarTaskName
-                            task([type: Jar], _jarTaskName) {
-                                dependsOn variant.javaCompiler
-                                from variant.javaCompiler.destinationDir
-                                exclude '**/R.class', '**/R$*.class', '**/R.html', '**/R.*.html'
-                            }
-                        }
-
-                        // Prepare our publication artifact (from the AAR)
-                        def _packageTask = tasks[_jarTaskName]
-                        def _component = project.components.findByName("java")
-
-                        // Also get the AAR itself, to publish alongside
-                        def _bundleTask = tasks['bundle' + _variantName + 'Aar']
-
-                        // Publish in our maven repository
-                        def _versionCode = version.versionCode
-                        publishing.publications.create(_variant, MavenPublication) {
-                            from _component
-                            artifact _bundleTask
-                            artifact _publishSourcesJar
-                            pom {
-                                packaging = 'jar'
-                                withXml {
-                                    asNode().appendNode('properties')
-                                            .appendNode('versionCode', _versionCode)
+                                    groupId = _group
+                                    artifactId = _name
+                                    version = _version
                                 }
-                            }
-                        }
-
-                        // The "javadocVariantName" task might not be here quite just yet
-                        tasks.all { _javadocTask ->
-                            // Ignore if not named "javadocVariantName"
-                            if (_javadocTask.name != 'javadoc' + _variantName) return
-
-                            // Create a "publishVariantNameJavadocJar" task from the _javadocTask
-                            def _publishJavadocJar = task([type: Jar], 'publish' + _variantName + 'JavadocJar') {
-                                dependsOn _javadocTask
-                                classifier = 'javadoc'
-                                from _javadocTask.destinationDir
-                            }
-
-                            // Add the Javadoc JAR artifact to our publication
-                            publishing.publications.getByName(_variant) { publication ->
-                                publication.artifact _publishJavadocJar
                             }
                         }
                     }
@@ -137,48 +84,18 @@ class PublishPlugin implements Plugin<Project> {
                 /* ================================================================== */
 
                 plugins.withId('com.android.application') {
+                    afterEvaluate {
+                        publishing {
+                            publications {
+                                def _group = group
+                                def _name = name
+                                def _version = version
+                                release(MavenPublication) {
+                                    from components.release_apk
 
-                    // By default we publish the "release" variant
-                    def _variant = Utilities.resolveValue(project, 'publishVariant', 'PUBLISH_VARIANT', 'release')
-                    def _variantName = _variant.capitalize()
-
-                    // Process all the application variants
-                    android.applicationVariants.all { variant ->
-                        if (variant.name != _variant) {
-                            logger.info('Skipping publishing of "{}" variant', variant.name)
-                            return;
-                        }
-
-                        // The package task (creates APK) and version code
-                        def _packageTask = tasks['package' + _variantName]
-                        def _versionCode = version.versionCode
-
-                        // Make sure we *depend* on the package task
-                        tasks['publish'].dependsOn _packageTask
-
-                        // Create our APK publication
-                        publishing.publications.create(_variant, MavenPublication) {
-                            _packageTask.outputs.files.each {
-                                logger.debug("debugInfo: output files {}", it.toString())
-                                def files = it.listFiles(new FileFilter() {
-                                    @Override
-                                    boolean accept(File file) {
-                                        if (file.name.endsWith(".apk") && file.name.contains(_variant)) {
-                                            return true;
-                                        }
-                                        return false
-                                    }
-                                })
-                                if (files != null && files.length > 0) {
-                                    File apk = files[0]
-                                    artifact apk.absolutePath
-                                    pom {
-                                        packaging = 'apk'
-                                        withXml {
-                                            asNode().appendNode('properties')
-                                                    .appendNode('versionCode', _versionCode)
-                                        }
-                                    }
+                                    groupId = _group
+                                    artifactId = _name
+                                    version = _version
                                 }
                             }
                         }

--- a/src/main/groovy/de/lemona/gradle/plugins/PublishPlugin.groovy
+++ b/src/main/groovy/de/lemona/gradle/plugins/PublishPlugin.groovy
@@ -2,199 +2,195 @@ package de.lemona.gradle.plugins
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.internal.artifacts.publish.ArchivePublishArtifact
-import org.gradle.api.internal.java.JavaLibrary
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.bundling.Jar
 
 class PublishPlugin implements Plugin<Project> {
 
-  void apply(Project project) {
-    // We just trigger our configurations on version/properties
-    project.plugins.withId('maven-publish') {
-      project.configure(project) {
+    void apply(Project project) {
+        // We just trigger our configurations on version/properties
+        project.plugins.withId('maven-publish') {
+            project.configure(project) {
 
-        // Our local (test) maven repository
-        def _repositoryPath = new File(buildDir, 'maven')
+                // Our local (test) maven repository
+                def _repositoryPath = new File(buildDir, 'maven')
 
-        // Inform where we are publishing to
-        logger.info('Publishing artifacts to \"{}\"', _repositoryPath.toURI())
+                // Inform where we are publishing to
+                logger.info('Publishing artifacts to \"{}\"', _repositoryPath.toURI())
 
-        // Inject our repository
-        publishing {
-          repositories {
-            maven {
-              url _repositoryPath
-            }
-          }
-        }
-
-        /* ================================================================== */
-        /* JAVA PROJECT PUBLISHING                                            */
-        /* ================================================================== */
-
-        plugins.withId('java') {
-
-          // Sources JAR for publishing
-          task([type: Jar], 'publishSourcesJar') {
-            classifier = 'sources'
-            from sourceSets.main.allSource
-          }
-
-          // JavaDoc JAR for publishing
-          task([type: Jar, dependsOn: javadoc], 'publishJavadocJar') {
-            classifier = 'javadoc'
-            from javadoc.destinationDir
-          }
-
-          // Create a "java" maven publication *AFTER* the project has been
-          // evaluated. If we do this now, dependencies will not be included...
-          afterEvaluate {
-            publishing.publications.create('java', MavenPublication) {
-              from components.java
-              artifact publishSourcesJar
-              artifact publishJavadocJar
-            }
-          }
-        }
-
-        /* ================================================================== */
-        /* ANDROID LIBRARY PROJECT PUBLISHING                                 */
-        /* ================================================================== */
-
-        plugins.withId('com.android.library') {
-
-          // By default we publish the "release" variant
-          def _variant = Utilities.resolveValue(project, 'publishVariant', 'PUBLISH_VARIANT', 'release')
-          def _variantName = _variant.capitalize()
-
-          // Process all the library variants
-          android.libraryVariants.all { variant ->
-            if (variant.name != _variant) {
-              logger.info('Skipping publishing of "{}" variant', variant.name)
-              return;
-            }
-
-            // Sources JAR for publishing
-            def _publishSourcesJar = task([type: Jar], 'publish' + _variantName + 'SourcesJar') {
-              classifier = 'sources'
-              from android.sourceSets.main.javaDirectories
-              from android.sourceSets.main.resourcesDirectories
-            }
-
-            def _jarTaskName = 'package' + _variantName + 'Jar'
-            if (tasks.findByName(_jarTaskName) == null) {
-              println 'No Jar task found, creating one: ' + _jarTaskName
-              task([type: Jar], _jarTaskName) {
-                dependsOn variant.javaCompiler
-                from variant.javaCompiler.destinationDir
-                exclude '**/R.class', '**/R$*.class', '**/R.html', '**/R.*.html'
-              }
-            }
-
-            // Prepare our publication artifact (from the AAR)
-            def _packageTask = tasks[_jarTaskName]
-            def _artifact = new ArchivePublishArtifact(_packageTask);
-            def _dependencies = configurations.compile.dependencies
-            def _component = new JavaLibrary(_artifact, _dependencies);
-
-            // Also get the AAR itself, to publish alongside
-            def _bundleTask = tasks['bundle' + _variantName + 'Aar']
-
-            // Publish in our maven repository
-            def _versionCode = version.versionCode
-            publishing.publications.create(_variant, MavenPublication) {
-              from _component
-              artifact _bundleTask
-              artifact _publishSourcesJar
-              pom {
-                packaging = 'jar'
-                withXml {
-                  asNode().appendNode('properties')
-                          .appendNode('versionCode', _versionCode)
-                }
-              }
-            }
-
-            // The "javadocVariantName" task might not be here quite just yet
-            tasks.all { _javadocTask ->
-              // Ignore if not named "javadocVariantName"
-              if (_javadocTask.name != 'javadoc' + _variantName) return
-
-              // Create a "publishVariantNameJavadocJar" task from the _javadocTask
-              def _publishJavadocJar = task([type: Jar], 'publish' + _variantName + 'JavadocJar') {
-                dependsOn _javadocTask
-                classifier = 'javadoc'
-                from _javadocTask.destinationDir
-              }
-
-              // Add the Javadoc JAR artifact to our publication
-              publishing.publications.getByName(_variant) { publication ->
-                publication.artifact _publishJavadocJar
-              }
-            }
-          }
-        }
-
-        /* ================================================================== */
-        /* ANDROID APPLICATION PROJECT PUBLISHING                             */
-        /* ================================================================== */
-
-        plugins.withId('com.android.application') {
-
-          // By default we publish the "release" variant
-          def _variant = Utilities.resolveValue(project, 'publishVariant', 'PUBLISH_VARIANT', 'release')
-          def _variantName = _variant.capitalize()
-
-          // Process all the application variants
-          android.applicationVariants.all { variant ->
-            if (variant.name != _variant) {
-              logger.info('Skipping publishing of "{}" variant', variant.name)
-              return;
-            }
-
-            // The package task (creates APK) and version code
-            def _packageTask = tasks['package' + _variantName]
-            def _versionCode = version.versionCode
-
-            // Make sure we *depend* on the package task
-            tasks['publish'].dependsOn _packageTask
-
-            // Create our APK publication
-            publishing.publications.create(_variant, MavenPublication) {
-              _packageTask.outputs.files.each {
-                logger.debug("debugInfo: output files {}", it.toString())
-                def files = it.listFiles(new FileFilter() {
-                  @Override
-                  boolean accept(File file) {
-                    if (file.name.endsWith(".apk") && file.name.contains(_variant)) {
-                      return true;
+                // Inject our repository
+                publishing {
+                    repositories {
+                        maven {
+                            url _repositoryPath
+                        }
                     }
-                    return false
-                  }
-                })
-                if (files != null && files.length > 0) {
-                  File apk = files[0]
-                  artifact apk.absolutePath
-                  pom {
-                    packaging = 'apk'
-                    withXml {
-                      asNode().appendNode('properties')
-                              .appendNode('versionCode', _versionCode)
-                    }
-                  }
                 }
-              }
+
+                /* ================================================================== */
+                /* JAVA PROJECT PUBLISHING                                            */
+                /* ================================================================== */
+
+                plugins.withId('java') {
+
+                    // Sources JAR for publishing
+                    task([type: Jar], 'publishSourcesJar') {
+                        classifier = 'sources'
+                        from sourceSets.main.allSource
+                    }
+
+                    // JavaDoc JAR for publishing
+                    task([type: Jar, dependsOn: javadoc], 'publishJavadocJar') {
+                        classifier = 'javadoc'
+                        from javadoc.destinationDir
+                    }
+
+                    // Create a "java" maven publication *AFTER* the project has been
+                    // evaluated. If we do this now, dependencies will not be included...
+                    afterEvaluate {
+                        publishing.publications.create('java', MavenPublication) {
+                            from components.java
+                            artifact publishSourcesJar
+                            artifact publishJavadocJar
+                        }
+                    }
+                }
+
+                /* ================================================================== */
+                /* ANDROID LIBRARY PROJECT PUBLISHING                                 */
+                /* ================================================================== */
+
+                plugins.withId('com.android.library') {
+
+                    // By default we publish the "release" variant
+                    def _variant = Utilities.resolveValue(project, 'publishVariant', 'PUBLISH_VARIANT', 'release')
+                    def _variantName = _variant.capitalize()
+
+                    // Process all the library variants
+                    android.libraryVariants.all { variant ->
+                        if (variant.name != _variant) {
+                            logger.info('Skipping publishing of "{}" variant', variant.name)
+                            return;
+                        }
+
+                        // Sources JAR for publishing
+                        def _publishSourcesJar = task([type: Jar], 'publish' + _variantName + 'SourcesJar') {
+                            classifier = 'sources'
+                            from android.sourceSets.main.javaDirectories
+                            from android.sourceSets.main.resourcesDirectories
+                        }
+
+                        def _jarTaskName = 'package' + _variantName + 'Jar'
+                        if (tasks.findByName(_jarTaskName) == null) {
+                            println 'No Jar task found, creating one: ' + _jarTaskName
+                            task([type: Jar], _jarTaskName) {
+                                dependsOn variant.javaCompiler
+                                from variant.javaCompiler.destinationDir
+                                exclude '**/R.class', '**/R$*.class', '**/R.html', '**/R.*.html'
+                            }
+                        }
+
+                        // Prepare our publication artifact (from the AAR)
+                        def _packageTask = tasks[_jarTaskName]
+                        def _component = project.components.findByName("java")
+
+                        // Also get the AAR itself, to publish alongside
+                        def _bundleTask = tasks['bundle' + _variantName + 'Aar']
+
+                        // Publish in our maven repository
+                        def _versionCode = version.versionCode
+                        publishing.publications.create(_variant, MavenPublication) {
+                            from _component
+                            artifact _bundleTask
+                            artifact _publishSourcesJar
+                            pom {
+                                packaging = 'jar'
+                                withXml {
+                                    asNode().appendNode('properties')
+                                            .appendNode('versionCode', _versionCode)
+                                }
+                            }
+                        }
+
+                        // The "javadocVariantName" task might not be here quite just yet
+                        tasks.all { _javadocTask ->
+                            // Ignore if not named "javadocVariantName"
+                            if (_javadocTask.name != 'javadoc' + _variantName) return
+
+                            // Create a "publishVariantNameJavadocJar" task from the _javadocTask
+                            def _publishJavadocJar = task([type: Jar], 'publish' + _variantName + 'JavadocJar') {
+                                dependsOn _javadocTask
+                                classifier = 'javadoc'
+                                from _javadocTask.destinationDir
+                            }
+
+                            // Add the Javadoc JAR artifact to our publication
+                            publishing.publications.getByName(_variant) { publication ->
+                                publication.artifact _publishJavadocJar
+                            }
+                        }
+                    }
+                }
+
+                /* ================================================================== */
+                /* ANDROID APPLICATION PROJECT PUBLISHING                             */
+                /* ================================================================== */
+
+                plugins.withId('com.android.application') {
+
+                    // By default we publish the "release" variant
+                    def _variant = Utilities.resolveValue(project, 'publishVariant', 'PUBLISH_VARIANT', 'release')
+                    def _variantName = _variant.capitalize()
+
+                    // Process all the application variants
+                    android.applicationVariants.all { variant ->
+                        if (variant.name != _variant) {
+                            logger.info('Skipping publishing of "{}" variant', variant.name)
+                            return;
+                        }
+
+                        // The package task (creates APK) and version code
+                        def _packageTask = tasks['package' + _variantName]
+                        def _versionCode = version.versionCode
+
+                        // Make sure we *depend* on the package task
+                        tasks['publish'].dependsOn _packageTask
+
+                        // Create our APK publication
+                        publishing.publications.create(_variant, MavenPublication) {
+                            _packageTask.outputs.files.each {
+                                logger.debug("debugInfo: output files {}", it.toString())
+                                def files = it.listFiles(new FileFilter() {
+                                    @Override
+                                    boolean accept(File file) {
+                                        if (file.name.endsWith(".apk") && file.name.contains(_variant)) {
+                                            return true;
+                                        }
+                                        return false
+                                    }
+                                })
+                                if (files != null && files.length > 0) {
+                                    File apk = files[0]
+                                    artifact apk.absolutePath
+                                    pom {
+                                        packaging = 'apk'
+                                        withXml {
+                                            asNode().appendNode('properties')
+                                                    .appendNode('versionCode', _versionCode)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
-          }
         }
-      }
     }
-  }
 
-  def canBeResolved(configuration) {
-    // isCanBeResolved() was introduced with Gradle 3.3 so check for its existence first
-    configuration.metaClass.respondsTo(configuration, "isCanBeResolved") ?
-            configuration.isCanBeResolved() : true
-  }
+    def canBeResolved(configuration) {
+        // isCanBeResolved() was introduced with Gradle 3.3 so check for its existence first
+        configuration.metaClass.respondsTo(configuration, "isCanBeResolved") ?
+                configuration.isCanBeResolved() : true
+    }
 }

--- a/src/main/groovy/de/lemona/gradle/plugins/PublishPlugin.groovy
+++ b/src/main/groovy/de/lemona/gradle/plugins/PublishPlugin.groovy
@@ -61,6 +61,7 @@ class PublishPlugin implements Plugin<Project> {
         /* ================================================================== */
 
         plugins.withId('com.android.library') {
+          // cf. https://developer.android.com/studio/build/maven-publish-plugin
           afterEvaluate {
             publishing {
               publications {
@@ -84,6 +85,7 @@ class PublishPlugin implements Plugin<Project> {
         /* ================================================================== */
 
         plugins.withId('com.android.application') {
+          // cf. https://developer.android.com/studio/build/maven-publish-plugin
           afterEvaluate {
             publishing {
               publications {

--- a/src/main/groovy/de/lemona/gradle/plugins/PublishPlugin.groovy
+++ b/src/main/groovy/de/lemona/gradle/plugins/PublishPlugin.groovy
@@ -7,101 +7,101 @@ import org.gradle.api.tasks.bundling.Jar
 
 class PublishPlugin implements Plugin<Project> {
 
-    void apply(Project project) {
-        // We just trigger our configurations on version/properties
-        project.plugins.withId('maven-publish') {
-            project.configure(project) {
+  void apply(Project project) {
+    // We just trigger our configurations on version/properties
+    project.plugins.withId('maven-publish') {
+      project.configure(project) {
 
-                // Our local (test) maven repository
-                def _repositoryPath = new File(buildDir, 'maven')
+        // Our local (test) maven repository
+        def _repositoryPath = new File(buildDir, 'maven')
 
-                // Inform where we are publishing to
-                logger.info('Publishing artifacts to \"{}\"', _repositoryPath.toURI())
+        // Inform where we are publishing to
+        logger.info('Publishing artifacts to \"{}\"', _repositoryPath.toURI())
 
-                // Inject our repository
-                publishing {
-                    repositories {
-                        maven {
-                            url _repositoryPath
-                        }
-                    }
-                }
-
-                /* ================================================================== */
-                /* JAVA PROJECT PUBLISHING                                            */
-                /* ================================================================== */
-
-                plugins.withId('java') {
-
-                    // Sources JAR for publishing
-                    task([type: Jar], 'publishSourcesJar') {
-                        classifier = 'sources'
-                        from sourceSets.main.allSource
-                    }
-
-                    // JavaDoc JAR for publishing
-                    task([type: Jar, dependsOn: javadoc], 'publishJavadocJar') {
-                        classifier = 'javadoc'
-                        from javadoc.destinationDir
-                    }
-
-                    // Create a "java" maven publication *AFTER* the project has been
-                    // evaluated. If we do this now, dependencies will not be included...
-                    afterEvaluate {
-                        publishing.publications.create('java', MavenPublication) {
-                            from components.java
-                            artifact publishSourcesJar
-                            artifact publishJavadocJar
-                        }
-                    }
-                }
-
-                /* ================================================================== */
-                /* ANDROID LIBRARY PROJECT PUBLISHING                                 */
-                /* ================================================================== */
-
-                plugins.withId('com.android.library') {
-                    afterEvaluate {
-                        publishing {
-                            publications {
-                                def _group = group
-                                def _name = name
-                                def _version = version
-                                release(MavenPublication) {
-                                    from components.release
-
-                                    groupId = _group
-                                    artifactId = _name
-                                    version = _version
-                                }
-                            }
-                        }
-                    }
-                }
-
-                /* ================================================================== */
-                /* ANDROID APPLICATION PROJECT PUBLISHING                             */
-                /* ================================================================== */
-
-                plugins.withId('com.android.application') {
-                    afterEvaluate {
-                        publishing {
-                            publications {
-                                def _group = group
-                                def _name = name
-                                def _version = version
-                                release(MavenPublication) {
-                                    from components.release_apk
-
-                                    groupId = _group
-                                    artifactId = _name
-                                    version = _version
-                                }
-                            }
-                        }
-                    }
-                }
+        // Inject our repository
+        publishing {
+          repositories {
+            maven {
+              url _repositoryPath
             }
+          }
         }
+
+        /* ================================================================== */
+        /* JAVA PROJECT PUBLISHING                                            */
+        /* ================================================================== */
+
+        plugins.withId('java') {
+
+          // Sources JAR for publishing
+          task([type: Jar], 'publishSourcesJar') {
+            classifier = 'sources'
+            from sourceSets.main.allSource
+          }
+
+          // JavaDoc JAR for publishing
+          task([type: Jar, dependsOn: javadoc], 'publishJavadocJar') {
+            classifier = 'javadoc'
+            from javadoc.destinationDir
+          }
+
+          // Create a "java" maven publication *AFTER* the project has been
+          // evaluated. If we do this now, dependencies will not be included...
+          afterEvaluate {
+            publishing.publications.create('java', MavenPublication) {
+              from components.java
+              artifact publishSourcesJar
+              artifact publishJavadocJar
+            }
+          }
+        }
+
+        /* ================================================================== */
+        /* ANDROID LIBRARY PROJECT PUBLISHING                                 */
+        /* ================================================================== */
+
+        plugins.withId('com.android.library') {
+          afterEvaluate {
+            publishing {
+              publications {
+                def _group = group
+                def _name = name
+                def _version = version
+                release(MavenPublication) {
+                  from components.release
+
+                  groupId = _group
+                  artifactId = _name
+                  version = _version
+                }
+              }
+            }
+          }
+        }
+
+        /* ================================================================== */
+        /* ANDROID APPLICATION PROJECT PUBLISHING                             */
+        /* ================================================================== */
+
+        plugins.withId('com.android.application') {
+          afterEvaluate {
+            publishing {
+              publications {
+                def _group = group
+                def _name = name
+                def _version = version
+                release(MavenPublication) {
+                  from components.release_apk
+
+                  groupId = _group
+                  artifactId = _name
+                  version = _version
+                }
+              }
+            }
+          }
+        }
+      }
     }
+  }
 }

--- a/updating.md
+++ b/updating.md
@@ -1,5 +1,15 @@
 # Updating individual projects
 
+## Version 0.3.0
+0.3.0 supports Gradle 5.
+You can use the latest (as 2020) Android gradle plugin in dependent Android projects.
+However, the publishing plugin doesn't have a backward compatibility for Android projects.
+So, please update the followings:
+
+* Gradle -> 5.6.4
+* Android Plugin -> 3.6.0
+* Android Build Tools -> 28.0.3 or later
+
 ## Version 0.1.0
 
 The 0.1.0 version of this plugin is fully backward compatible. Simply bumping its version in dependent projects will have no side effects.


### PR DESCRIPTION
## Objective
Adapt to Gradle 5

## Updates
- 独自のAndroidのpublishを削除
   - [Android gradle plugin](https://developer.android.com/studio/build/maven-publish-plugin)の3.6.0から、publishがサポートされたので、それをそのまま使うように変更
- readme.md, updating.mdを更新