### PR TITLE
build: update com.gradle.plugin-publish to 0.12.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java-gradle-plugin'
-    id 'com.gradle.plugin-publish' version '0.9.9'
-    id 'de.lemona.gradle' version '0.1.5'
+    id 'com.gradle.plugin-publish' version '0.12.0'
+    id 'de.lemona.gradle' version '0.2.6'
 }
 
 apply plugin: 'groovy'


### PR DESCRIPTION
# Objective
Update `com.gradle.plugin-publish`

portalへのpublishは0.11.0以上が必須になってた。

https://blog.gradle.org/plugin-portal-update

> Old versions of the com.gradle.plugin-publish plugin will no longer work. 
