### PR TITLE
feat: switch plugin application by flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ customize the standard build conventions to the ones used at
 
 Supported Version
 -----------------
-* Gradle 2.13 - 4.0.1
-* Android 1.5.0/2.1.0 - 2.3.0
+* Gradle 2.13 - 5.6.4
+* Android plugin 3.6.0
 
 In order to take advantage of the latest versions of Gradle and Android, see  [updating.md](updating.md).
 
@@ -78,6 +78,7 @@ This plugin will:
      plugin was specified in the build file.
    * Add the [S3 Repository Plugin](#s3-repository-plugin) if the project has
      the `s3.repository` property or `S3_REPOSITORY` environment variable.
+   > <small>_Note:_ if you'd like to avoid using these libraries, set `leomo.enableAutoPluginApply` property (or `LEOMO_ENABLE_AUTO_PLUGIN_APPLY` environment variable) to false. Default true.</small>
 
 The plugin will also inject a `lemonade` extension in the project containing
 few utility methods:

--- a/src/main/groovy/de/lemona/gradle/plugins/GradlePlugin.groovy
+++ b/src/main/groovy/de/lemona/gradle/plugins/GradlePlugin.groovy
@@ -19,23 +19,29 @@ class GradlePlugin implements Plugin<Project> {
         // Configure the project
         project.configure(project) {
 
-            // Trigger actions on our plugins
-            plugins.withId('java') { project.apply plugin: 'de.lemona.gradle.java' }
-            plugins.withId('java-library') { project.apply plugin: 'de.lemona.gradle.java' }
-            plugins.withId('maven-publish') { project.apply plugin: 'de.lemona.gradle.publish' }
+            Boolean _autoPluginApply = Utilities.resolveValue(project, 'leomo.enableAutoPluginApply', 'LEOMO_ENABLE_AUTO_PLUGIN_APPLY', true).toBoolean()
 
-            plugins.withId('com.android.application') {
-                project.apply plugin: 'de.lemona.gradle.android'
-            }
-            plugins.withId('com.android.library') {
-                project.apply plugin: 'de.lemona.gradle.android'
-            }
+            if (_autoPluginApply) {
+                logger.debug('Start applying suitable plugins')
 
-            plugins.withId('com.jfrog.bintray') { project.apply plugin: 'de.lemona.gradle.bintray' }
+                // Trigger actions on our plugins
+                plugins.withId('java') { project.apply plugin: 'de.lemona.gradle.java' }
+                plugins.withId('java-library') { project.apply plugin: 'de.lemona.gradle.java' }
+                plugins.withId('maven-publish') { project.apply plugin: 'de.lemona.gradle.publish' }
 
-            // S3 plugin gets triggered by property/env variable....
-            if (Utilities.resolveValue(project, 's3.repository', 'S3_REPOSITORY') != null) {
-                project.apply plugin: 'de.lemona.gradle.s3'
+                plugins.withId('com.android.application') {
+                    project.apply plugin: 'de.lemona.gradle.android'
+                }
+                plugins.withId('com.android.library') {
+                    project.apply plugin: 'de.lemona.gradle.android'
+                }
+
+                plugins.withId('com.jfrog.bintray') { project.apply plugin: 'de.lemona.gradle.bintray' }
+
+                // S3 plugin gets triggered by property/env variable....
+                if (Utilities.resolveValue(project, 's3.repository', 'S3_REPOSITORY') != null) {
+                    project.apply plugin: 'de.lemona.gradle.s3'
+                }
             }
 
             // Configure the default repositories: ours, google, jcenter, and maven central

--- a/updating.md
+++ b/updating.md
@@ -1,6 +1,8 @@
 # Updating individual projects
 ## Version 0.3.8
-The main plugin (`de.lemona.gradle`) automatically applies other plugins based on the build file of dependent projects, as default.
+This version supports `leomo.enableAutoPluginApply` to enable/disable automatic plugin binding.
+
+As default, the main plugin (`de.lemona.gradle`) automatically applies other plugins based on the build file of dependent projects.
 
 If you'd like to apply these plugins manually, please set the property to `false`.
 

--- a/updating.md
+++ b/updating.md
@@ -1,7 +1,11 @@
 # Updating individual projects
+## Version 0.3.8
+The main plugin (`de.lemona.gradle`) automatically applies other plugins based on the build file of dependent projects, as default.
 
-## Version 0.3.0
-0.3.0 supports Gradle 5.
+If you'd like to apply these plugins manually, please set the property to `false`.
+
+## Version 0.3.7
+0.3.7 supports Gradle 5.
 You can use the latest (as 2020) Android gradle plugin in dependent Android projects.
 However, the publishing plugin doesn't have a backward compatibility for Android projects.
 So, please update the followings:


### PR DESCRIPTION
# Objective
gradle-snippetsへの依存軽減案。

# Updates
- `leomo.enableAutoPluginApply=false`にすると、自動で他のpluginを適用する処理をスキップ

例えば、Androidアプリで「S3 pluginは使いたいが、Android pluginは必要ない」場合、
以下のように設定すれば、必要なものだけ適用される。

gradle.properties
```
leomo.enableAutoPluginApply=false
```

build.gradle
```
plugins {
    id 'de.lemona.gradle' version '0.3.8'
    id 'de.lemona.gradle.s3' version '0.3.8'
}
```