### PR TITLE
build: delete plugins block from pluinBundle block

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,12 +30,6 @@ pluginBundle {
     vcsUrl = 'https://github.com/LemonadeLabInc/gradle-snippets'
     description = 'LEOMO Android and Java conventions plugin'
     tags = ['leomo']
-    plugins {
-        gradle {
-            id = 'de.lemona.gradle'
-            displayName = 'LEOMO Gradle plugin'
-        }
-    }
 }
 
 gradlePlugin {
@@ -55,6 +49,7 @@ gradlePlugin {
         gradlePlugin {
             id = 'de.lemona.gradle'
             implementationClass = 'de.lemona.gradle.plugins.GradlePlugin'
+            displayName = 'LEOMO Gradle plugin'
         }
         publishPlugin {
             id = 'de.lemona.gradle.publish'


### PR DESCRIPTION
# Objective
plugin portalへのpublishが失敗する問題への対応

```
Execution failed for task ':publishPlugins'.
> Invalid plugin ID 'de.lemona.gradle': multiple plugins are using the same ID
```

# Updates
Sampleと同じフォーマットにしてみる

https://guides.gradle.org/publishing-plugins-to-gradle-plugin-portal/#configure_the_plugin_publishing_plugin

```
Now specify the details of the plugin. This is done in a plugins block within the gradlePlugin block. The most important part is the id property,
```